### PR TITLE
Remove daemon set checking in admission plugin

### DIFF
--- a/pkg/scheduler/admission/podnodeconstraints/admission.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission.go
@@ -77,7 +77,6 @@ func (o *podNodeConstraints) Admit(attr admission.Attributes) error {
 	switch attr.GetResource() {
 	case kapi.Resource("pods"),
 		kapi.Resource("replicationcontrollers"),
-		extensions.Resource("daemonsets"),
 		extensions.Resource("deployments"),
 		extensions.Resource("replicasets"),
 		extensions.Resource("jobs"),
@@ -99,8 +98,6 @@ func (o *podNodeConstraints) getPodSpec(attr admission.Attributes) (kapi.PodSpec
 	case *kapi.Pod:
 		return r.Spec, nil
 	case *kapi.ReplicationController:
-		return r.Spec.Template.Spec, nil
-	case *extensions.DaemonSet:
 		return r.Spec.Template.Spec, nil
 	case *extensions.Deployment:
 		return r.Spec.Template.Spec, nil


### PR DESCRIPTION
As discussed with Derek on Friday, if you are allowed to create a daemon set, we should do no further checking within the plugin.