### PR TITLE
Fix conversion test

### DIFF
--- a/pkg/scheduler/admission/podnodeconstraints/api/v1/conversion_test.go
+++ b/pkg/scheduler/admission/podnodeconstraints/api/v1/conversion_test.go
@@ -6,7 +6,9 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util/sets"
 
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/scheduler/admission/podnodeconstraints/api"
+	_ "github.com/openshift/origin/pkg/scheduler/admission/podnodeconstraints/api/install"
 	versioned "github.com/openshift/origin/pkg/scheduler/admission/podnodeconstraints/api/v1"
 )
 
@@ -14,11 +16,11 @@ func TestConversions(t *testing.T) {
 	input := &versioned.PodNodeConstraintsConfig{
 		NodeSelectorLabelBlacklist: []string{"test"},
 	}
-	expected := api.PodNodeConstraintsConfig{
+	expected := &api.PodNodeConstraintsConfig{
 		NodeSelectorLabelBlacklist: sets.NewString([]string{"test"}...),
 	}
 	output := &api.PodNodeConstraintsConfig{}
-	err := kapi.Scheme.Convert(input, output)
+	err := configapi.Scheme.Convert(input, output)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
A couple of things wrong here. You needed to include the install package
so that conversions that you wrote are loaded. You also can't encode
using the kapi scheme, because we use the configapi scheme.